### PR TITLE
i18n対応の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,14 +29,16 @@ gem "tailwindcss-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 
-# 新しく追加
+# 画像をアップロードするためのgem
 gem 'carrierwave', '~> 3.0'
+# 画像をAWS S3にアップロードするためのgem
 gem 'fog-aws'
 # 環境変数を使うためのgem
 gem 'dotenv-rails'
 # ユーザー認証システムを実装するためのgem
 gem 'sorcery'
-
+# i18nのためのgem
+gem 'rails-i18n'
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,6 +250,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.9)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.1.3.2)
       actionpack (= 7.1.3.2)
       activesupport (= 7.1.3.2)
@@ -347,6 +350,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
+  rails-i18n
   selenium-webdriver
   sorcery
   sprockets-rails

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <div class=" col-md-10 col-lg-8 mx-auto">
-      <h1>ログイン</h1>
+      <h1><%= t('.title') %></h1>
       <%= form_with url: login_path do |f| %>
         <div class="mb-3">
           <%= f.label :email %>
@@ -11,11 +11,11 @@
           <%= f.label :password %>
           <%= f.password_field :password, class: "form-control" %>
         </div>
-        <%= f.submit "ログイン", class: "btn btn-primary" %>
+        <%= f.submit t('.login'), class: "btn btn-primary" %>
       <% end %>
       <div class='text-center'>
-        <%= link_to '登録ページへ', new_user_path %>
-        <%= link_to 'パスワードをお忘れの方はこちら', '#' %>
+        <%= link_to t('.to_register_page'), new_user_path %>
+        <%= link_to t('.password_forget'), '#' %>
       </div>
     </div>
   </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <div class="col-md-10 col-lg-8 mx-auto">
-      <h1>がはく登録</h1>
+      <h1><%= t('.title') %></h1>
       <%= form_with model: @user do |f| %>
         <div class="mb-3">
           <%= f.label :name, class: "form-label" %>
@@ -19,10 +19,10 @@
           <%= f.label :password_confirmation, class: "form-label" %>
           <%= f.password_field :password_confirmation, class: "form-control" %>
         </div>
-        <%= f.submit "登録", class: "btn btn-primary" %>
+        <%= f.submit class: "btn btn-primary" %>
       <% end %>
       <div class='text-center'>
-        <%= link_to 'ログインページへ', login_path %>
+        <%= link_to t('.to_login_page'), login_path %>
       </div>
     </div>
   </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,5 +28,8 @@ module GahakuNoKimochi
       g.test_framework false     # test ファイルを作成しない
       g.skip_routes true         # ルーティングの記述を作成しない
     end
+
+    # i18nのデフォルトのロケールを日本語(:ja)に設定
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,10 @@
+ja:
+  activerecord:  # ActiveRecordモデルとその属性名に対応
+    models:      # モデル名
+      user: ユーザー
+    attributes:  # モデルの属性名
+      user:      # userモデル内の属性名
+        email: メールアドレス
+        name: 名前
+        password: パスワード
+        password_confirmation: パスワード確認

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,24 @@
+ja:
+  helpers:      # フォームヘルパーに対応(create, update, submitを判別してくれる)
+    submit: 
+      create: 登録
+      submit: 保存
+      update: 更新
+    label:
+      email: メールアドレス
+      password: パスワード
+  user_sessions: # app/views/user_sessionsに対応
+    new:         # app/views/user_sessions/new.html.erbに対応
+      title: ログイン
+      login: ログイン
+      to_register_page: 登録ページへ
+      password_forget: パスワードをお忘れの方はこちら
+  users:         # app/views/usersに対応
+    new:         # app/views/users/new.html.erbに対応
+      title: ユーザー登録
+      to_login_page: ログインページへ
+  header:        # app/views/layouts/_header.html.erbに対応
+    login: ログイン
+    logout: ログアウト
+    profile: プロフィール
+    # ヘッダーの明記確定後に追加していく


### PR DESCRIPTION
## 概要
i18nによる日本語化対応
## 内容
- i18nのデフォルト設定を:jaに設定
- gem 'rails-i18n'のインストール
- ja.ymlの作成
  - config/locales/activerecord/ja.yml
  - config/locales/views/ja.yml
- 該当ビューを日本語化
  - app/views/users/new.html.erb
  - app/views/user_sessions/new.html.erb