### PR TITLE
しりとり、画像の投稿機能の追加

### DIFF
--- a/app/controllers/drawings_controller.rb
+++ b/app/controllers/drawings_controller.rb
@@ -1,0 +1,20 @@
+class DrawingsController < ApplicationController
+  def new
+    @drawing = Drawing.new
+  end
+
+  def create
+    @drawing = current_user.drawings.build(drawing_params)
+    if @drawing.save
+      redirect_to shiritori_game_path(@drawing.shiritori_game)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def drawing_params
+    params.require(:drawing).permit(:title, :artwork, :artwork_cache, :turn_count, :shiritori_game_id)
+  end
+end

--- a/app/controllers/shiritori_games_controller.rb
+++ b/app/controllers/shiritori_games_controller.rb
@@ -1,0 +1,31 @@
+class ShiritoriGamesController < ApplicationController
+  def new
+    @shiritori_game = ShiritoriGame.new
+  end
+
+  def create
+    @shiritori_game = ShiritoriGame.new(shiritori_game_params)
+    if @shiritori_game.save
+      redirect_to new_shiritori_game_drawing_path(@shiritori_game), notice: 'ゲームのお題を作成しました! あなたが1人目のがはくとなりましょう!'
+    else
+      flash.now[:alert] = 'お題の作成に失敗しました。'
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def index
+    @shiritori_games = ShiritoriGame.all
+  end
+
+  def show
+    @shiritori_game = ShiritoriGame.find(params[:id])
+    @drawing = Drawing.new
+    @drawings = @shiritori_game.drawings.includes(:user)
+  end
+
+  private
+
+  def shiritori_game_params
+    params.require(:shiritori_game).permit(:game_title, :status)
+  end
+end

--- a/app/models/drawing.rb
+++ b/app/models/drawing.rb
@@ -1,0 +1,12 @@
+class Drawing < ApplicationRecord
+  # userモデルと1対多の関係を記述
+  belongs_to :user
+  # shiritori_gameモデルと1対多の関係を記述
+  belongs_to :shiritori_game
+  # 画像をアップロードするための記述
+  mount_uploader :artwork, ArtworkUploader
+  # turn_countカラムでenumを使用（1ターン目、2ターン目、3ターン目、4ターン目、5ターン目）の5つの状態を持つ
+  enum turn_count: { first_turn: 0, second_turn: 1, third_turn: 2, fourth_turn: 3, fifth_turn: 4 }
+  # titleカラムに対して、値が空でないこと・最大15文字以下であること
+  validates :title, presence: true, length: { maximum: 15 }
+end

--- a/app/models/shiritori_game.rb
+++ b/app/models/shiritori_game.rb
@@ -1,0 +1,8 @@
+class ShiritoriGame < ApplicationRecord
+  # drawingモデルと多対1の関係を記述
+  has_many :drawings, dependent: :destroy
+  # statusカラムでenumを使用（進行中、成功、失敗）の3つの状態を持つ
+  enum status: { in_progress: 0, success: 1, failure: 2 }
+  # titleカラムに対して、値が空でないこと・最大255文字以下であること
+  validates :game_title, presence: true, length: { maximum: 255 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  # drawingモデルと多対1の関係を記述
+  has_many :drawings, dependent: :destroy
   # password；最小で3文字以上必要（新規レコード作成もしくはcrypted_passwordカラムが更新される時のみ適応）
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   # password_confirmation：値が空でないこと・passwordの値と一致すること（新規レコード作成もしくはcrypted_passwordカラムが更新される時のみ適応）

--- a/app/uploaders/artwork_uploader.rb
+++ b/app/uploaders/artwork_uploader.rb
@@ -1,0 +1,47 @@
+class ArtworkUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # S3導入に伴い、storage :fileをstorage :fogに変更
+  # storage :file
+  storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_allowlist
+    %w(jpg jpeg gif png)
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg"
+  # end
+end

--- a/app/views/drawings/new.html.erb
+++ b/app/views/drawings/new.html.erb
@@ -1,0 +1,32 @@
+<!-- app/views/drawings/new.html.erb -->
+<h1 class="text-2xl font-bold mb-4">新しい描画を作成</h1>
+<%= form_with model: @drawing, url: shiritori_game_drawings_path, local: true, class: "form-control" do |form| %>
+
+  <div class="form-group mb-4">
+    <%= form.label :title, "タイトル", class: "label" %>
+    <%= form.text_field :title, class: "input input-bordered w-full" %>
+  </div>
+
+  <div class="form-group mb-4">
+    <%= form.label :turn_count, "ターン数", class: "label" %>
+    <%= form.select :turn_count, Drawing.turn_counts.keys.map { |w| [w.humanize, w] }, {}, class: "select select-bordered w-full" %>
+  </div>
+
+  <div class="form-group mb-4">
+    <%= form.label :artwork, "アートワーク", class: "label" %>
+    <%= form.file_field :artwork, class: "file-input file-input-bordered w-full" %>
+    <%= form.hidden_field :artwork_cache %>
+  </div>
+
+  <div class="form-group mb-4">
+    <%= image_tag @drawing.artwork_url, id: "preview", width: "300", height: "200" if @drawing.artwork.present? %>
+  </div>
+
+  <%= form.hidden_field :shiritori_game_id, value: params[:shiritori_game_id] %>
+
+  <div class="form-group">
+    <%= form.submit "描画を作成", class: "btn btn-primary" %>
+  </div>
+<% end %>
+
+<%= link_to 'キャンセル', shiritori_game_path(params[:shiritori_game_id]), class: "btn btn-secondary mt-4" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,6 +10,9 @@
     <div class="flex-none">
       <ul class="menu menu-horizontal px-1">
         <li>
+          <%= link_to 'がはくしりとり', shiritori_games_path %>
+        </li>
+        <li>
           <%= link_to 'クイズを作る', new_question_path %>
         </li>
         <li>

--- a/app/views/shiritori_games/index.html.erb
+++ b/app/views/shiritori_games/index.html.erb
@@ -1,0 +1,25 @@
+
+<%= link_to '新しいしりとりゲームを作成', new_shiritori_game_path, class: "btn btn-primary mb-4" %>
+
+<table class="table w-full">
+  <thead>
+    <tr>
+      <th>タイトル</th>
+      <th>ステータス</th>
+      <th>作成日時</th>
+      <th>操作</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @shiritori_games.each do |game| %>
+      <tr>
+        <td><%= game.game_title %></td>
+        <td><%= game.status.humanize %></td>
+        <td><%= game.created_at.strftime("%Y-%m-%d %H:%M:%S") %></td>
+        <td>
+          <%= link_to '表示', shiritori_game_path(game), class: "btn btn-secondary btn-sm" %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/shiritori_games/new.html.erb
+++ b/app/views/shiritori_games/new.html.erb
@@ -1,0 +1,27 @@
+<h1 class="text-2xl font-bold mb-4">ゲームのお題を作成しましょう！<br>しばりをつけると面白くなるかも！</h1>
+
+
+<%= form_with model: @shiritori_game, local: true, class: "form-control" do |form| %>
+  <% if @shiritori_game.errors.any? %>
+    <div id="error_explanation" class="alert alert-error mb-4">
+      <ul>
+        <% @shiritori_game.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="form-group mb-4">
+    <%= form.label :game_title, class: "label" %>
+    <%= form.text_field :game_title, class: "input input-bordered w-full", placeholder: '3文字で, 一筆書きで など' %>
+  </div>
+
+  <%= form.hidden_field :status, value: "in_progress" %>
+
+  <div class="form-group">
+    <%= form.submit class: "btn btn-primary" %>
+  </div>
+<% end %>
+
+  

--- a/app/views/shiritori_games/show.html.erb
+++ b/app/views/shiritori_games/show.html.erb
@@ -1,0 +1,12 @@
+<h1 class="text-2xl font-bold mb-4"><%= @shiritori_game.game_title %></h1>
+
+<p class="text-lg mb-2">ステータス: <%= @shiritori_game.status.humanize %></p>
+<p class="text-lg mb-4">作成日時: <%= @shiritori_game.created_at.strftime("%Y-%m-%d %H:%M:%S") %></p>
+
+<h2 class="text-xl font-bold mb-4">描画一覧</h2>
+<% @drawings.each do |d|%>
+  <%= image_tag d.artwork_url, width: 300, height: 300 %>
+<% end %>
+
+<%= link_to 'しりとりを続ける', new_shiritori_game_drawing_path(@shiritori_game), class: "btn btn-secondary mt-4" %>
+<%= link_to '一覧に戻る', shiritori_games_path, class: "btn btn-secondary mt-4" %>

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,6 +3,8 @@ require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
+  # 開発環境と本番環境で保存先を変更
+  if Rails.env.production?
     config.storage :fog
     config.fog_provider = 'fog/aws'
     config.fog_directory  = 'kahakunobucket' # 作成したバケット名
@@ -13,4 +15,8 @@ CarrierWave.configure do |config|
       region: 'ap-northeast-1',   # アジアパシフィック(東京)を選択した場合
       path_style: true
     }
+  else
+    config.storage = :file
+    config.enable_processing = Rails.env.development?
+  end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,4 +1,4 @@
-ja:
+ja:              # form_withで使われるヘルパーに対応
   activerecord:  # ActiveRecordモデルとその属性名に対応
     models:      # モデル名
       user: ユーザー
@@ -8,3 +8,5 @@ ja:
         name: 名前
         password: パスワード
         password_confirmation: パスワード確認
+      shiritori_game:
+        game_title: お題

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -7,6 +7,8 @@ ja:
     label:
       email: メールアドレス
       password: パスワード
+      password_confirmation: パスワード確認
+      game_title: お題
   user_sessions: # app/views/user_sessionsに対応
     new:         # app/views/user_sessions/new.html.erbに対応
       title: ログイン
@@ -22,3 +24,7 @@ ja:
     logout: ログアウト
     profile: プロフィール
     # ヘッダーの明記確定後に追加していく
+  shiritori_games:
+    new:
+      title: お題作成
+      game_title: お題

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,7 @@ Rails.application.routes.draw do
   get 'questions/answer', to: 'questions#answer', :as => :answer
   get 'questions/correct', to: 'questions#correct', :as => :correct
   get 'questions/incorrect', to: 'questions#incorrect', :as => :incorrect
+  resources :shiritori_games, only: %i[new create index show] do
+    resources :drawings, only: %i[new create index]
+  end
 end

--- a/db/migrate/20240611124607_create_shiritori_games.rb
+++ b/db/migrate/20240611124607_create_shiritori_games.rb
@@ -1,0 +1,10 @@
+class CreateShiritoriGames < ActiveRecord::Migration[7.1]
+  def change
+    create_table :shiritori_games do |t|
+      t.string :game_title,       null: false
+      t.integer :status,          default: 0, null: false
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240611124608_create_drawings.rb
+++ b/db/migrate/20240611124608_create_drawings.rb
@@ -1,0 +1,15 @@
+class CreateDrawings < ActiveRecord::Migration[7.1]
+  def change
+    create_table :drawings do |t|
+      t.integer :user_id,            null: false
+      t.integer :shiritori_game_id, null: false
+      t.string :artwork,             null: false
+      t.string :title,               null: false, limit: 15
+      t.integer :turn_count,         default: 0, null: false
+      
+      t.timestamps
+    end
+    add_foreign_key :drawings, :users, column: :user_id
+    add_foreign_key :drawings, :shiritori_games, column: :shiritori_game_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_11_013018) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_11_124608) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,10 +22,27 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_11_013018) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "drawings", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "shiritori_game_id", null: false
+    t.string "artwork", null: false
+    t.string "title", limit: 15, null: false
+    t.integer "turn_count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "questions", force: :cascade do |t|
     t.string "image", null: false
     t.string "author", null: false
     t.string "age", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "shiritori_games", force: :cascade do |t|
+    t.string "game_title", null: false
+    t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -41,4 +58,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_11_013018) do
   end
 
   add_foreign_key "choices", "questions"
+  add_foreign_key "drawings", "shiritori_games"
+  add_foreign_key "drawings", "users"
 end


### PR DESCRIPTION
## 概要
しりとり機能、画像投稿機能の追加
## 内容
### しりとり機能
- shiritori_gameモデル、shiritori_gamesコントローラ作成
- viewファイル（app/views/shiritori_games）の作成
  - new.html.erb
  - index.html.erb
  - show.html.erb
### 画像投稿機能
- drawingモデル、drawingsコントローラ作成
- viewファイル（app/views/drawings）の作成
  - new.html.erb